### PR TITLE
Use grunt.file.expand

### DIFF
--- a/tasks/cpplint.js
+++ b/tasks/cpplint.js
@@ -35,7 +35,7 @@ module.exports = function (grunt) {
 
 		options.filters = extend(filters.defaults, gruntFilters, true);
 
-		options.files = grunt.file.expandFiles(conf('files'));
+		options.files = grunt.file.expand(conf('files'));
 		options.verbosity = conf('verbosity') || 1;
 		options.counting = conf('counting') || 'toplevel';
 


### PR DESCRIPTION
grunt.file.expandFiles is no longer available in Grunt 0.4+.

Let me know if you still want support pre-0.4 and I can add a fallback to still use `expandFiles` if it is available.
