### PR TITLE
Properly separate filters with commas

### DIFF
--- a/lib/make-args.js
+++ b/lib/make-args.js
@@ -35,36 +35,34 @@ function counting(type) {
  */
 function filter(filters) {
   var categories = Object.keys(filters),
-    result = '';
+    filterSettings = [];
 
   categories.forEach(function (categoryName) {
 
     var index, subcategory, value,
       category = filters[categoryName],
       subcategories = Object.keys(category),
-      length = subcategories.length;
+      length = subcategories.length,
+      filterSetting = '';
 
     for (index = 0; index < length; index += 1) {
       subcategory = subcategories[index];
       value = category[subcategory];
+      filterSetting = '';
 
       if (value) {
-        result += '+';
+        filterSetting += '+';
       } else {
-        result += '-';
+        filterSetting += '-';
       }
 
-      result += categoryName + '/' + subcategory;
-
-      if (index !== (length - 1)) {
-        result += ',';
-      }
-
+      filterSetting += categoryName + '/' + subcategory;
+      filterSettings.push(filterSetting);
     }
 
   });
 
-  return '--filter=' + result;
+  return '--filter=' + filterSettings.join(',');
 }
 /*
 function filter(excluded) {

--- a/test/make-args.js
+++ b/test/make-args.js
@@ -98,7 +98,7 @@ suite.addBatch({
       assert.includes(args, '/path/to/file1 /path/to/file2');
     },
     'should pass the correct filters': function (err, args) {
-      assert.includes(args, '--filter=+category1/subcat1,-category1/subcat2,+category1/subcat3+category2/subcat1,-category2/subcat2,+category2/subcat3,+category2/subcat4,-category2/subcat5,+category2/subcat6');
+      assert.includes(args, '--filter=+category1/subcat1,-category1/subcat2,+category1/subcat3,+category2/subcat1,-category2/subcat2,+category2/subcat3,+category2/subcat4,-category2/subcat5,+category2/subcat6');
     }
 
   },
@@ -144,6 +144,9 @@ suite.addBatch({
         'subcat4': true,
         'subcat5': false,
         'subcat6': true
+      },
+      'category3': {
+        'subcat1': true
       }
     }),
     'should return a string': function (filters) {
@@ -171,6 +174,9 @@ suite.addBatch({
     'should disable subcats 2 and 5 in category2': function (filters) {
       assert.includes(filters, '-category2/subcat2');
       assert.includes(filters, '-category2/subcat5');
+    },
+    'should include a comma between filters': function (filters) {
+      assert.include(filters.split(','), '+category3/subcat1');
     }
   }
 });


### PR DESCRIPTION
I was trying to disable the `legal/copyright` and I was unable to and dug in a bit and found that commas weren't always be placed between in the filter values when generated.
