### PR TITLE
Added vows task to Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,16 +2,23 @@
 
 module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-jslint');
+  grunt.loadNpmTasks("grunt-vows");
   grunt.loadTasks('./tasks');
 
   // Project configuration.
   grunt.initConfig({
 
+    vows: {
+      src: [
+        'test/*.js'
+      ]
+    },
+
     jslint: {
       files: [
         'lib/**/*.js',
         'test/**/*.js',
-        'grunt.js'
+        'Gruntfile.js'
       ],
       directives: {
         node: true,


### PR DESCRIPTION
The Contributing section in the readme mentioned running the unit tests before sending a pull request. From a clean checkout I couldn't run `grunt vows`. So I added the grunt-vows module. I also changed the jslint config to lint Gruntfile.js since 'grunt.js' doesn't exist.
