### PR TITLE
Don't pass in all filters to cpplint

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -3,91 +3,13 @@
 var extend = require('./extend.js');
 
 /**
- * Each possible error, all enabled by default (other than build/include_alpha)
- * @type {Object}
- */
-var defaults = {
-  'build': {
-    'class': true,
-    'c++11': true,
-    'deprecated': true,
-    'endif_comment': true,
-    'explicit_make_pair': true,
-    'forward_decl': true,
-    'header_guard': true,
-    'include': true,
-    // for whatever reason, by default, cpplint has this turned off by default
-    'include_alpha': false,
-    'include_order': true,
-    'include_what_you_use': true,
-    'namespaces': true,
-    'printf_format': true,
-    'storage_class': true
-  },
-  'legal': {
-    'copyright': true
-  },
-  'readability': {
-    'alt_tokens': true,
-    'braces': true,
-    'casting': true,
-    'check': true,
-    'constructors': true,
-    'fn_size': true,
-    'function': true,
-    'multiline_comment': true,
-    'multiline_string': true,
-    'nolint': true,
-    'nul': true,
-    'streams': true,
-    'todo': true,
-    'utf8': true
-  },
-  'runtime': {
-    'arrays': true,
-    'casting': true,
-    'explicit': true,
-    'int': true,
-    'init': true,
-    'invalid_increment': true,
-    'member_string_references': true,
-    'memset': true,
-    'operator': true,
-    'printf': true,
-    'printf_format': true,
-    'references': true,
-    'string': true,
-    'threadsafe_fn': true,
-    'vlog': true
-  },
-  'whitespace': {
-    'blank_line': true,
-    'braces': true,
-    'comma': true,
-    'comments': true,
-    'empty_conditional_body': true,
-    'empty_loop_body': true,
-    'end_of_line': true,
-    'ending_newline': true,
-    'indent': true,
-    'line_length': true,
-    'newline': true,
-    'operators': true,
-    'parens': true,
-    'semicolon': true,
-    'tab': true,
-    'todo': true
-  }
-};
-
-/**
  * Parse a command-line list of excludes and convert into an object
  *
  * @param  {String} str
  * @return {Object}
  */
 function parse(str) {
-  var result = extend({}, defaults),
+  var result = {},
     excludes = str.split(',');
 
   excludes.forEach(function (option) {
@@ -103,9 +25,8 @@ function parse(str) {
       return;
     }
 
-    // non-supported categories
     if (!result.hasOwnProperty(category)) {
-      return;
+      result[category] = {};
     }
 
     result[category][subcategory] = false;
@@ -116,6 +37,5 @@ function parse(str) {
 }
 
 module.exports = {
-  'defaults': defaults,
   'parse': parse
 };

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -23,7 +23,6 @@ var MIN_VERBOSITY = 0;
 var defaults = {};
 defaults.verbosity = 1;
 defaults.counting = 'total';
-defaults.filters = require('./filters.js').defaults;
 
 /**
  * @async

--- a/tasks/cpplint.js
+++ b/tasks/cpplint.js
@@ -33,7 +33,7 @@ module.exports = function (grunt) {
       return false;
     }
 
-    options.filters = extend(filters.defaults, gruntFilters, true);
+    options.filters = gruntFilters;
 
     options.extensions = conf('extensions');
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -10,6 +10,8 @@ var path = require('path');
 
 var execFile = require('child_process').execFile;
 
+var exec = require('child_process').exec;
+
 var suite = vows.describe('cli');
 
 suite.addBatch({
@@ -45,6 +47,20 @@ suite.addBatch({
     'default extensions is no extensions': function (err, stdout, stderr) {
       var lines = stdout.split('\n');
       assert.lengthOf(lines, 7);
+    }
+  },
+
+  'filters': {
+    topic: function () {
+      exec(path.join(__dirname, '..', 'bin', 'cpplint') + ' --filters legal-copyright,' +
+          'build-namespaces,whitespace-braces ' + path.join(__dirname, 'fixtures', 'node-cpp-hello.cpp'),
+          this.callback);
+    },
+
+    'should exclude the filters': function (err, stdout, stderr) {
+      var lines = stdout.split('\n');
+      assert.lengthOf(lines, 2);
+      assert.match(lines[0], /✓/);
     }
   }
 });

--- a/test/lint-error.js
+++ b/test/lint-error.js
@@ -228,7 +228,6 @@ suite.addBatch({
       assert.equal(lintError.linenumber, '1');
     },
     'should have correct reason': function (err, lintError) {
-      console.log(lintError);
       assert.equal(lintError.reason, '<future> is an unapproved C++11 header.');
     },
     'should have correct category': function (err, lintError) {

--- a/test/parse-options.js
+++ b/test/parse-options.js
@@ -37,6 +37,9 @@ suite.addBatch({
       assert.equal(result.verbosity, 1);
 
       assert.equal(result.counting, 'total');
+    },
+    'should not pass in filters': function (err, result) {
+      assert.equal(result.filters, undefined);
     }
   },
 


### PR DESCRIPTION
This PR removes the default filters and lets cpplint use its own defaults
