### PR TITLE
Set proper exit code when  cpplint.py detects lint errors.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -22,11 +22,16 @@ function runner(options, next) {
 
     /*jslint unparam:true*/
     exec(args.join(' ').trim(), function (err, stdout, stderr) {
-
       return parseOutput(stderr, next);
+    }).on('exit', function (exitCode) {
+      process.exitCode = exitCode;
     });
     /*jslint unparam:false*/
   });
 }
+
+process.on('exit', function () {
+  process.exit(process.exitCode);
+});
 
 module.exports = runner;

--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
   },
   "devDependencies": {
     "grunt": "~0.4.1",
+    "grunt-cli": "^1.2.0",
     "grunt-jslint": "~1.1.12",
-    "vows": "~0.7.0",
-    "grunt-vows": "~0.4.0"
+    "grunt-vows": "~0.4.0",
+    "vows": "~0.7.0"
   }
 }


### PR DESCRIPTION
This will allow users to run node-cpplint in shell scripts and not force
them to use grunt-cpplint when that is not necessary.

node-cpplint src/** || echo "The C++ lint failed with exit code $?"

I was unable to get the tests to work for this because I do not know how to stub process.on and reset the process.exitCode in vowsjs testing framework.